### PR TITLE
Add scripts for running tests in jenkins

### DIFF
--- a/container_test.sh
+++ b/container_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+echo "==> Getting code coverage tools"
+go get -v github.com/jstemmer/go-junit-report
+
+echo "==> Getting dependencies"
+go get -v ./...
+
+echo "==> Running tests and gathering coverage"
+rm -f acc.out
+for Dir in $(go list ./... | grep -v "/vendor/" );
+do
+    go test -v $Dir | tee -a acc.out
+done
+
+echo "==> Outputting coverage report"
+cat acc.out | go-junit-report > coverage.xml
+
+## Credit to: https://github.com/KevinPike

--- a/run_test_container.sh
+++ b/run_test_container.sh
@@ -1,0 +1,2 @@
+repo="github.com/waieez/fbforbots"
+docker run -v "$PWD:/go/src/$repo" --rm -w "/go/src/$repo" golang:1.6.2 /bin/bash -c "./container_test.sh"


### PR DESCRIPTION
In Jenkins, runs a script to launch a go container.
Container runs another script to run the go test command.

Unfortunately requires a hosted jenkins server for this to work.

#7 